### PR TITLE
Add new props and CSS handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,28 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.1.0] - 2019-07-01
 ### Added
+
+- New `isFullWidth` and `slideDirection` props to `Drawer` component.
+- Support for `.drawerBurguer`, `drawerCloseContainer` and `drawerCloseButton` CSS handles.
+
+## [0.1.0] - 2019-07-01
+
+### Added
+
 - Allow `rich-text` and `flex-layout` blocks on drawer.
 
 ## [0.0.6] - 2019-06-07
+
 ### Fixed
+
 - Fix typo on tachyons class.
 - Fix width of drawer.
 
 ## [0.0.5] - 2019-05-25
+
 ### Fixed
+
 - Prevent scroll from locking when the Drawer is unmounted without being closed.
 - Add scroll to drawer element.
 - Locks scroll on iOS
@@ -25,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.0.4] - 2019-05-22
 
 ### Added
+
 - Added category-menu to interfaces.json
 
 ## [0.0.3] - 2019-05-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - New `isFullWidth`, `slideDirection` and `maxWidth` props to `Drawer` component.
-- Support for `.drawerBurguer`, `drawerCloseContainer` and `drawerCloseButton` CSS handles.
+- Support for `.openIconContainer`, `closeIconContainer` and `closeIconButton` CSS handles.
 
 ## [0.1.0] - 2019-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- New `isFullWidth` and `slideDirection` props to `Drawer` component.
+- New `isFullWidth`, `slideDirection` and `maxWidth` props to `Drawer` component.
 - Support for `.drawerBurguer`, `drawerCloseContainer` and `drawerCloseButton` CSS handles.
 
 ## [0.1.0] - 2019-07-01

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 This component allows you to have a sliding drawer for your menus. This is specially handy for mobile layouts.
 
-**The instruction below are for using this component outside of the Blocks API**
-
 ## Basic Usage
 
 To configure or customize this app, you need to import it in your dependencies in your `manifest.json` file.
@@ -14,7 +12,28 @@ dependencies: {
 }
 ```
 
-and import it inside the component you want to use it in. Here's an example:
+Then, you need to add the `drawer` block into your app. The following is an example taken from [Store Theme](https://github.com/vtex-apps/store-theme).
+
+```json
+  "drawer": {
+    "children": [
+      "menu#drawer"
+    ]
+  },
+
+  "menu#drawer": {
+    "children": [
+      "menu-item#category-clothing",
+      "menu-item#category-decoration",
+      "menu-item#custom-sale"
+    ],
+    "props": {
+      "orientation": "vertical"
+    }
+  },
+```
+
+If you're using this component by itself, you just need to import it inside the component you want to use it in. Here's an example:
 
 ```tsx
 import { Drawer } from 'vtex.store-drawer'

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ const Menu = () => (
 
 The Drawer component accepts a few props that allow you to customize it.
 
-| Prop name        | Type              | Description                                                                          | Default value  |
-| ---------------- | ----------------- | ------------------------------------------------------------------------------------ | -------------- |
-| `maxWidth`       | `Number | String` | Define the open Drawer's maximum width.                                              | `450`          |
-| `isFullWidth`    | `Boolean`         | Control whether or not the open Drawer should occupy the full available width.       | `false`        |
-| `slideDirection` | `Enum`            | Controls the opening animation's direction. (values: `'vertical'` or `'horizontal'`) | `'horizontal'` |
+| Prop name        | Type                 | Description                                                                          | Default value  |
+| ---------------- | -------------------- | ------------------------------------------------------------------------------------ | -------------- |
+| `maxWidth`       | `Number` or `String` | Define the open Drawer's maximum width.                                              | `450`          |
+| `isFullWidth`    | `Boolean`            | Control whether or not the open Drawer should occupy the full available width.       | `false`        |
+| `slideDirection` | `Enum`               | Controls the opening animation's direction. (values: `'vertical'` or `'horizontal'`) | `'horizontal'` |
 
 ### Styles API
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To use this CSS API, you must add the `styles` builder and create an app styling
 
 #### CSS Namespaces
 
-Below, we describe the namespaces that are defined in the product-summary.
+Below, we describe the namespaces that are defined in the `store-drawer`.
 
 | Token name           | Description                                                        |
 | -------------------- | ------------------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -1,1 +1,73 @@
-# store-drawer
+# Store Drawer
+
+This component allows you to have a sliding drawer for your menus. This is specially handy for mobile layouts.
+
+**The instruction below are for using this component outside of the Blocks API**
+
+## Basic Usage
+
+To configure or customize this app, you need to import it in your dependencies in your `manifest.json` file.
+
+```json
+dependencies: {
+  "vtex.store-drawer": "0.x"
+}
+```
+
+and import it inside the component you want to use it in. Here's an example:
+
+```tsx
+import { Drawer } from 'vtex.store-drawer'
+
+const Menu = () => (
+  <Drawer>
+    <nav>
+      <ul>
+        <li>Link 1</li>
+        <li>Link 2</li>
+        <li>Link 3</li>
+        <li>Link 4</li>
+        <li>Link 5</li>
+        <li>Link 6</li>
+      </ul>
+    </nav>
+  </Drawer>
+)
+```
+
+## Configuration
+
+The Drawer component accepts a few props that allow you to customize it.
+
+| Prop name        | Type              | Description                                                                          | Default value  |
+| ---------------- | ----------------- | ------------------------------------------------------------------------------------ | -------------- |
+| `maxWidth`       | `Number | String` | Define the open Drawer's maximum width.                                              | `450`          |
+| `isFullWidth`    | `Boolean`         | Control whether or not the open Drawer should occupy the full available width.       | `false`        |
+| `slideDirection` | `Enum`            | Controls the opening animation's direction. (values: `'vertical'` or `'horizontal'`) | `'horizontal'` |
+
+### Styles API
+
+This app provides some CSS classes as an API for style customization.
+
+To use this CSS API, you must add the `styles` builder and create an app styling CSS file.
+
+1. Add the `styles` builder to your `manifest.json`:
+
+```json
+  "builders": {
+    "styles": "1.x"
+  }
+```
+
+2. Create a file called `vtex.store-drawer.css` inside the `styles/css` folder and add your custom using regular CSS.
+
+#### CSS Namespaces
+
+Below, we describe the namespaces that are defined in the product-summary.
+
+| Token name           | Description                                                        |
+| -------------------- | ------------------------------------------------------------------ |
+| `drawer`             | The main container of the `Drawer` component.                      |
+| `openIconContainer`  | The container of icon that opens the Drawer when clicked.          |
+| `closeIconContainer` | The container of icon that closes the Drawer when clicked.         |
+| `closeIconButton`    | The button around of the icon that closes the Drawer when clicked. |

--- a/README.md
+++ b/README.md
@@ -15,22 +15,22 @@ dependencies: {
 Then, you need to add the `drawer` block into your app. The following is an example taken from [Store Theme](https://github.com/vtex-apps/store-theme).
 
 ```json
-  "drawer": {
-    "children": [
-      "menu#drawer"
-    ]
-  },
+"drawer": {
+  "children": [
+    "menu#drawer"
+  ]
+},
 
-  "menu#drawer": {
-    "children": [
-      "menu-item#category-clothing",
-      "menu-item#category-decoration",
-      "menu-item#custom-sale"
-    ],
-    "props": {
-      "orientation": "vertical"
-    }
-  },
+"menu#drawer": {
+  "children": [
+    "menu-item#category-clothing",
+    "menu-item#category-decoration",
+    "menu-item#custom-sale"
+  ],
+  "props": {
+    "orientation": "vertical"
+  }
+},
 ```
 
 If you're using this component by itself, you just need to import it inside the component you want to use it in. Here's an example:

--- a/README.md
+++ b/README.md
@@ -21,16 +21,14 @@ import { Drawer } from 'vtex.store-drawer'
 
 const Menu = () => (
   <Drawer>
-    <nav>
-      <ul>
-        <li>Link 1</li>
-        <li>Link 2</li>
-        <li>Link 3</li>
-        <li>Link 4</li>
-        <li>Link 5</li>
-        <li>Link 6</li>
-      </ul>
-    </nav>
+    <ul>
+      <li>Link 1</li>
+      <li>Link 2</li>
+      <li>Link 3</li>
+      <li>Link 4</li>
+      <li>Link 5</li>
+      <li>Link 6</li>
+    </ul>
   </Drawer>
 )
 ```

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -147,7 +147,7 @@ const Drawer: StorefrontComponent<DrawerSchema & BlockClass> = ({
   return (
     <>
       <div
-        className={`pa4 pointer ${styles.drawerBurguer}`}
+        className={`pa4 pointer ${styles.openIconContainer}`}
         onClick={openMenu}
         aria-hidden
       >
@@ -180,10 +180,10 @@ const Drawer: StorefrontComponent<DrawerSchema & BlockClass> = ({
               minWidth: 280,
             }}
           >
-            <div className={`flex ${styles.drawerCloseContainer}`}>
+            <div className={`flex ${styles.closeIconButton}`}>
               <button
                 className={`pa4 pointer bg-transparent transparent bn pointer ${
-                  styles.drawerCloseButton
+                  styles.closeIconButton
                 }`}
                 onClick={closeMenu}
               >

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -122,6 +122,8 @@ const Drawer: StorefrontComponent<DrawerSchema & BlockClass> = ({
   // position,
   // width,
   // height,
+  isFullWidth,
+  slideDirection,
   blockClass,
   children,
 }) => {
@@ -133,10 +135,21 @@ const Drawer: StorefrontComponent<DrawerSchema & BlockClass> = ({
   } = useMenuState()
 
   const menuRef = useRef(null)
+  const slideFromTopToBottom = `translate3d(0, ${
+    isMenuOpen ? '0' : '-100%'
+  }, 0)`
+  const slideFromLeftToRight = `translate3d(${
+    isMenuOpen ? '0' : '-100%'
+  }, 0, 0)`
+  const isVertical = slideDirection === 'vertical'
 
   return (
     <>
-      <div className="pa4 pointer" onClick={openMenu} aria-hidden>
+      <div
+        className={`pa4 pointer w-100 ${styles.drawerBurguer}`}
+        onClick={openMenu}
+        aria-hidden
+      >
         <IconMenu size={20} />
       </div>
       <Portal>
@@ -156,17 +169,21 @@ const Drawer: StorefrontComponent<DrawerSchema & BlockClass> = ({
             style={{
               WebkitOverflowScrolling: 'touch',
               overflowY: 'scroll',
-              width: '85%',
+              width: isFullWidth ? '100%' : '85%',
               maxWidth: 450,
               pointerEvents: isMenuOpen ? 'auto' : 'none',
-              transform: `translate3d(${isMenuOpen ? '0' : '-100%'}, 0, 0)`,
+              transform: isVertical
+                ? slideFromTopToBottom
+                : slideFromLeftToRight,
               transition: isMenuTransitioning ? 'transform 300ms' : 'none',
               minWidth: 280,
             }}
           >
-            <div className="dib">
+            <div className={`flex ${styles.drawerCloseContainer}`}>
               <button
-                className="pa4 pointer bg-transparent transparent bn pointer"
+                className={`pa4 pointer bg-transparent transparent bn pointer ${
+                  styles.drawerCloseButton
+                }`}
                 onClick={closeMenu}
               >
                 <IconClose size={30} type="line" />

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -146,7 +146,7 @@ const Drawer: StorefrontComponent<DrawerSchema & BlockClass> = ({
   return (
     <>
       <div
-        className={`pa4 pointer w-100 ${styles.drawerBurguer}`}
+        className={`pa4 pointer ${styles.drawerBurguer}`}
         onClick={openMenu}
         aria-hidden
       >

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -122,6 +122,7 @@ const Drawer: StorefrontComponent<DrawerSchema & BlockClass> = ({
   // position,
   // width,
   // height,
+  maxWidth = 450,
   isFullWidth,
   slideDirection,
   blockClass,
@@ -170,7 +171,7 @@ const Drawer: StorefrontComponent<DrawerSchema & BlockClass> = ({
               WebkitOverflowScrolling: 'touch',
               overflowY: 'scroll',
               width: isFullWidth ? '100%' : '85%',
-              maxWidth: 450,
+              maxWidth,
               pointerEvents: isMenuOpen ? 'auto' : 'none',
               transform: isVertical
                 ? slideFromTopToBottom

--- a/react/drawer.css
+++ b/react/drawer.css
@@ -1,1 +1,11 @@
-.drawer {}
+.drawer {
+}
+
+.drawerBurguer {
+}
+
+.drawerCloseContainer {
+}
+
+.drawerCloseButton {
+}

--- a/react/drawer.css
+++ b/react/drawer.css
@@ -1,11 +1,11 @@
 .drawer {
 }
 
-.drawerBurguer {
+.openIconContainer {
 }
 
-.drawerCloseContainer {
+.closeIconContainer {
 }
 
-.drawerCloseButton {
+.closeIconButton {
 }

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -20,5 +20,7 @@ declare global {
     position: Position
     width: '100%' | 'auto'
     height: '100%' | 'auto' | 'fullscreen'
+    slideDirection: 'vertical' | 'horizontal'
+    isFullWidth: boolean
   }
 }

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -22,5 +22,6 @@ declare global {
     height: '100%' | 'auto' | 'fullscreen'
     slideDirection: 'vertical' | 'horizontal'
     isFullWidth: boolean
+    maxWidth: number | string
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add new props `isFullWidth`, `slideDirection` and `maxWidth` to the Drawer component.

- `isFullWidth` is a boolean, which allows the user to control whether or not the open Drawer should occupy the full width of the screen.
- `slideDirection` is either `vertical` or `horizontal` (default), controlling if the Drawer should open from top-to-bottom (`vertical`) or left-to-right(`horizontal`).
- `maxWidth` is either a number (a value in pixels) or a string, it controls the maxWidth of the open Drawer. If using the `isFullWidth` prop, this should come handy if you use the Drawer on screen sizes greater than 450px, which is the default value for this prop.

Add new CSS handles `.drawerBurguer`, `.drawerCloseContainer`, `.drawerCloseButton`.

Add new README.

#### What problem is this solving?

The user had no control over how the Drawer component looks, now they have control over how much of the screen is covered by it and can customize the positioning of the icons.

#### How should this be manually tested?

Take a look at this workspace: https://victorhmp--storecomponents.myvtex.com/docs/home.

I'm using my `store-theme` to define the following CSS for the `vtex.store-drawer` app:

```css
.drawerBurguer {
  display: flex;
  justify-content: center;
  padding-left: 0;
}

.drawerCloseContainer {
  justify-content: center;
}
```

Also, I'm using the two new props:

```jsx
<Drawer isFullWidth slideDirection="vertical">
```

#### Screenshots or example usage

<img width="379" alt="Screen Shot 2019-08-09 at 12 26 09 PM" src="https://user-images.githubusercontent.com/27777263/62790191-f5083400-baa0-11e9-9382-947fac76c31e.png">

<img width="376" alt="Screen Shot 2019-08-09 at 12 26 33 PM" src="https://user-images.githubusercontent.com/27777263/62790209-fc2f4200-baa0-11e9-8ed8-55e4789c7be6.png">


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Requires change to documentation, which has been updated accordingly.
