### PR TITLE
Lazy content rendering/Swipable update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Issue where client rendering on the Portal component would be inconsistent with SSR.
+- "Accordeon effect" when opening the drawer, when the scrollbars are visible in the user's OS.
 
 ## [0.5.0] - 2019-12-27
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allows dragging from outside of the drawer.
+
+### Changed
+- Preserves momentum after swipe release.
+- Prevents rendering of content if the menu has not been opened.
+
+### Fixed
+- Issue where client rendering on the Portal component would be inconsistent with SSR.
 
 ## [0.5.0] - 2019-12-27
 ### Changed

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -22,6 +22,7 @@ const getScrollPosition = () => {
 }
 
 const useLockScroll = () => {
+  const initialized = useRef(false)
   const [isLocked, setLocked] = useState(false)
   type ScrollPosition = number | null
   const [lockedScrollPosition, setLockedScrollPosition] = useState<
@@ -29,6 +30,13 @@ const useLockScroll = () => {
   >(null)
 
   useEffect(() => {
+    if (!initialized.current && !isLocked) {
+      // Prevent this from running at first, if it's not locked.
+      // Important because this triggers re-layout, thus slowing
+      // down the rendering unnecessarily.
+      initialized.current = true
+      return
+    }
     /** Locks scroll of the root HTML element if the
      * drawer menu is open
      */

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -87,12 +87,16 @@ const useLockScroll = () => {
 
 const useMenuState = () => {
   const [isMenuOpen, setIsOpen] = useState(false)
+  const [hasBeenOpened, setHasBeenOpened] = useState(false)
   const [isMenuTransitioning, setIsTransitioning] = useState(false)
   const setLockScroll = useLockScroll()
 
   let transitioningTimeout: number | null
 
   const setMenuOpen = (value: boolean) => {
+    if (!hasBeenOpened && value) {
+      setHasBeenOpened(true)
+    }
     setIsOpen(value)
     setIsTransitioning(true)
     setLockScroll(value)
@@ -111,7 +115,14 @@ const useMenuState = () => {
   const openMenu = () => setMenuOpen(true)
   const closeMenu = () => setMenuOpen(false)
 
-  return { isMenuOpen, isMenuTransitioning, setMenuOpen, openMenu, closeMenu }
+  return {
+    isMenuOpen,
+    isMenuTransitioning,
+    setMenuOpen,
+    openMenu,
+    closeMenu,
+    hasBeenOpened,
+  }
 }
 
 const CSS_HANDLES = [
@@ -141,6 +152,7 @@ const Drawer: StorefrontComponent<
     isMenuTransitioning,
     openMenu,
     closeMenu,
+    hasBeenOpened,
   } = useMenuState()
   const handles = useCssHandles(CSS_HANDLES)
   const menuRef = useRef(null)
@@ -209,14 +221,16 @@ const Drawer: StorefrontComponent<
           >
             <div className={`flex ${handles.closeIconContainer}`}>
               <button
-                className={`pa4 pointer bg-transparent transparent bn pointer ${handles.closeIconButton}`}
+                className={`pa4 pointer bg-transparent transparent bn pointer ${
+                  handles.closeIconButton
+                }`}
                 onClick={closeMenu}
               >
                 <IconClose size={30} type="line" />
               </button>
             </div>
             <div className={`${handles.childrenContainer} flex flex-grow-1`}>
-              {children}
+              {hasBeenOpened && children}
             </div>
           </div>
         </Swipable>

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -150,10 +150,6 @@ const CSS_HANDLES = [
 const Drawer: StorefrontComponent<
   DrawerSchema & { customIcon: ReactElement }
 > = ({
-  // actionIconId,
-  // dismissIconId,
-  // position,
-  // height,
   width,
   customIcon,
   maxWidth = 450,

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -44,7 +44,14 @@ const useLockScroll = () => {
 
     const documentElement =
       window && window.document && window.document.documentElement
+
     if (documentElement) {
+      const bodyBounds = document.body.getBoundingClientRect()
+
+      document.body.style.width = shouldLockScroll
+        ? `${bodyBounds.width}px`
+        : 'auto'
+
       documentElement.style.overflow = shouldLockScroll ? 'hidden' : 'auto'
 
       /** iOS doesn't lock the scroll of the body by just setting overflow to hidden.
@@ -75,7 +82,6 @@ const useLockScroll = () => {
 
       documentElement.style.bottom = shouldLockScroll ? '0' : 'auto'
       documentElement.style.left = shouldLockScroll ? '0' : 'auto'
-      documentElement.style.right = shouldLockScroll ? '0' : 'auto'
     }
 
     return () => {
@@ -85,7 +91,7 @@ const useLockScroll = () => {
       documentElement.style.top = 'auto'
       documentElement.style.bottom = 'auto'
       documentElement.style.left = 'auto'
-      documentElement.style.right = 'auto'
+      document.body.style.width = 'auto'
     }
   }, [isLocked]) // eslint-disable-line react-hooks/exhaustive-deps
   // ☝️ no need to trigger this on lockedScrollPosition changes

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect, ReactElement } from 'react'
+import React, { ReactElement, Suspense, useReducer } from 'react'
 import { defineMessages } from 'react-intl'
 
 import { IconClose, IconMenu } from 'vtex.store-icons'
@@ -6,136 +6,58 @@ import { useCssHandles } from 'vtex.css-handles'
 
 import Overlay from './Overlay'
 import Portal from './Portal'
-import Swipable from './Swipable'
+import useLockScroll from './modules/useLockScroll'
 
-// https://stackoverflow.com/a/3464890/5313009
-const getScrollPosition = () => {
-  const documentElement =
-    window && window.document && window.document.documentElement
-  if (!documentElement) {
-    return 0
-  }
-  return (
-    (window.pageYOffset || documentElement.scrollTop) -
-    (documentElement.clientTop || 0)
-  )
+const Swipable = React.lazy(() => import('./Swipable'))
+
+interface MenuState {
+  isOpen: boolean
+  hasBeenOpened: boolean
 }
 
-const useLockScroll = () => {
-  const initialized = useRef(false)
-  const [isLocked, setLocked] = useState(false)
-  type ScrollPosition = number | null
-  const [lockedScrollPosition, setLockedScrollPosition] = useState<
-    ScrollPosition
-  >(null)
+interface MenuAction {
+  type: 'open' | 'close'
+}
 
-  useEffect(() => {
-    if (!initialized.current && !isLocked) {
-      // Prevent this from running at first, if it's not locked.
-      // Important because this triggers re-layout, thus slowing
-      // down the rendering unnecessarily.
-      initialized.current = true
-      return
-    }
-    /** Locks scroll of the root HTML element if the
-     * drawer menu is open
-     */
-    const shouldLockScroll = isLocked
+const initialMenuState: MenuState = {
+  isOpen: false,
+  hasBeenOpened: false,
+}
 
-    const documentElement =
-      window && window.document && window.document.documentElement
-
-    if (documentElement) {
-      const bodyBounds = document.body.getBoundingClientRect()
-
-      document.body.style.width = shouldLockScroll
-        ? `${bodyBounds.width}px`
-        : 'auto'
-
-      documentElement.style.overflow = shouldLockScroll ? 'hidden' : 'auto'
-
-      /** iOS doesn't lock the scroll of the body by just setting overflow to hidden.
-       * It requires setting the position of the HTML element to fixed, which also
-       * resets the scroll position.
-       * This code is intended to record the scroll position and set it as
-       * the element's position, and revert it once the menu is closed.
-       */
-      const scrollPosition =
-        lockedScrollPosition == null
-          ? getScrollPosition()
-          : lockedScrollPosition
-
-      if (lockedScrollPosition == null && shouldLockScroll) {
-        setLockedScrollPosition(scrollPosition)
+function menuReducer(state: MenuState, action: MenuAction) {
+  switch (action.type) {
+    case 'open':
+      return {
+        ...state,
+        isOpen: true,
+        hasBeenOpened: true,
       }
-
-      if (lockedScrollPosition != null && !shouldLockScroll) {
-        window && window.scrollTo(0, scrollPosition)
-        setLockedScrollPosition(null)
+    case 'close':
+      return {
+        ...state,
+        isOpen: false,
       }
-
-      documentElement.style.position = shouldLockScroll ? 'fixed' : 'static'
-
-      documentElement.style.top = shouldLockScroll
-        ? `-${scrollPosition}px`
-        : 'auto'
-
-      documentElement.style.bottom = shouldLockScroll ? '0' : 'auto'
-      documentElement.style.left = shouldLockScroll ? '0' : 'auto'
-    }
-
-    return () => {
-      documentElement.style.overflow = 'auto'
-      documentElement.style.position = 'static'
-
-      documentElement.style.top = 'auto'
-      documentElement.style.bottom = 'auto'
-      documentElement.style.left = 'auto'
-      document.body.style.width = 'auto'
-    }
-  }, [isLocked]) // eslint-disable-line react-hooks/exhaustive-deps
-  // ☝️ no need to trigger this on lockedScrollPosition changes
-
-  return setLocked
+    default:
+      return state
+  }
 }
 
 const useMenuState = () => {
-  const [isMenuOpen, setIsOpen] = useState(false)
-  const [hasBeenOpened, setHasBeenOpened] = useState(false)
-  const [isMenuTransitioning, setIsTransitioning] = useState(false)
+  const [state, dispatch] = useReducer(menuReducer, initialMenuState)
   const setLockScroll = useLockScroll()
 
-  let transitioningTimeout: number | null
-
   const setMenuOpen = (value: boolean) => {
-    if (!hasBeenOpened && value) {
-      setHasBeenOpened(true)
-    }
-    setIsOpen(value)
-    setIsTransitioning(true)
+    dispatch({ type: value ? 'open' : 'close' })
     setLockScroll(value)
-
-    if (transitioningTimeout != null) {
-      clearTimeout(transitioningTimeout)
-      transitioningTimeout = null
-    }
-    transitioningTimeout =
-      window &&
-      window.setTimeout(() => {
-        setIsTransitioning(false)
-      }, 300)
   }
 
   const openMenu = () => setMenuOpen(true)
   const closeMenu = () => setMenuOpen(false)
 
   return {
-    isMenuOpen,
-    isMenuTransitioning,
-    setMenuOpen,
+    state,
     openMenu,
     closeMenu,
-    hasBeenOpened,
   }
 }
 
@@ -157,38 +79,16 @@ const Drawer: StorefrontComponent<
   slideDirection = 'horizontal',
   children,
 }) => {
-  const {
-    isMenuOpen,
-    isMenuTransitioning,
-    openMenu,
-    closeMenu,
-    hasBeenOpened,
-  } = useMenuState()
+  const { state: menuState, openMenu, closeMenu } = useMenuState()
+  const { isOpen: isMenuOpen, hasBeenOpened: hasMenuBeenOpened } = menuState
   const handles = useCssHandles(CSS_HANDLES)
-  const menuRef = useRef(null)
 
-  const slideFromTopToBottom = `translate3d(0, ${
-    isMenuOpen ? '0' : '-100%'
-  }, 0)`
-  const slideFromLeftToRight = `translate3d(${
-    isMenuOpen ? '0' : '-100%'
-  }, 0, 0)`
-  const slideFromRightToLeft = `translate3d(${isMenuOpen ? '0' : '100%'}, 0, 0)`
+  const direction =
+    slideDirection === 'horizontal' || slideDirection === 'leftToRight'
+      ? 'left'
+      : 'right'
 
-  const resolveSlideDirection = () => {
-    switch (slideDirection) {
-      case 'horizontal':
-        return slideFromLeftToRight
-      case 'vertical':
-        return slideFromTopToBottom
-      case 'leftToRight':
-        return slideFromLeftToRight
-      case 'rightToLeft':
-        return slideFromRightToLeft
-      default:
-        return slideFromLeftToRight
-    }
-  }
+  const swipeHandler = direction === 'left' ? 'onSwipeLeft' : 'onSwipeRight'
 
   return (
     <>
@@ -201,49 +101,44 @@ const Drawer: StorefrontComponent<
       </div>
       <Portal>
         <Overlay visible={isMenuOpen} onClick={closeMenu} />
-
-        <Swipable
-          enabled={isMenuOpen}
-          element={menuRef && menuRef.current}
-          onSwipeLeft={
-            slideDirection === 'horizontal' || slideDirection === 'leftToRight'
-              ? closeMenu
-              : null
-          }
-          onSwipeRight={slideDirection === 'rightToLeft' ? closeMenu : null}
-          rubberBanding
-        >
-          <div
-            ref={menuRef}
-            className={`${handles.drawer} fixed top-0 ${
-              slideDirection === 'rightToLeft' ? 'right-0' : 'left-0'
-            } bottom-0 bg-base z-999 flex flex-column`}
+        <Suspense fallback={<React.Fragment />}>
+          <Swipable
+            {...{
+              [swipeHandler]: closeMenu,
+            }}
+            enabled={isMenuOpen}
+            position={isMenuOpen ? 'center' : direction}
+            allowOutsideDrag
+            className={`${handles.drawer} ${
+              direction === 'right' ? 'right-0' : 'left-0'
+            } fixed top-0 bottom-0 bg-base z-999 flex flex-column`}
             style={{
-              WebkitOverflowScrolling: 'touch',
-              overflowY: 'scroll',
               width: width || (isFullWidth ? '100%' : '85%'),
               maxWidth,
-              pointerEvents: isMenuOpen ? 'auto' : 'none',
-              transform: resolveSlideDirection(),
-              transition: isMenuTransitioning ? 'transform 300ms' : 'none',
               minWidth: 280,
+              pointerEvents: isMenuOpen ? 'auto' : 'none',
             }}
           >
-            <div className={`flex ${handles.closeIconContainer}`}>
-              <button
-                className={`pa4 pointer bg-transparent transparent bn pointer ${
-                  handles.closeIconButton
-                }`}
-                onClick={closeMenu}
-              >
-                <IconClose size={30} type="line" />
-              </button>
+            <div
+              style={{
+                WebkitOverflowScrolling: 'touch',
+                overflowY: 'scroll',
+              }}
+            >
+              <div className={`flex ${handles.closeIconContainer}`}>
+                <button
+                  className={`${handles.closeIconButton} pa4 pointer bg-transparent transparent bn pointer`}
+                  onClick={closeMenu}
+                >
+                  <IconClose size={30} type="line" />
+                </button>
+              </div>
+              <div className={`${handles.childrenContainer} flex flex-grow-1`}>
+                {hasMenuBeenOpened && children}
+              </div>
             </div>
-            <div className={`${handles.childrenContainer} flex flex-grow-1`}>
-              {hasBeenOpened && children}
-            </div>
-          </div>
-        </Swipable>
+          </Swipable>
+        </Suspense>
       </Portal>
     </>
   )

--- a/react/Portal.tsx
+++ b/react/Portal.tsx
@@ -1,10 +1,12 @@
 import { FunctionComponent } from 'react'
 import ReactDOM from 'react-dom'
+import { useSSR } from 'vtex.render-runtime'
 
 const Portal: FunctionComponent = ({ children }) => {
   const body = window && window.document && window.document.body
+  const isSSR = useSSR()
 
-  if (!body) {
+  if (!body || isSSR) {
     return null
   }
 

--- a/react/Swipable.js
+++ b/react/Swipable.js
@@ -1,7 +1,5 @@
-// TODO: Move this to a separate npm package
-
 import React from 'react'
-import { animate } from './simpleAnimation'
+import { animate } from './modules/animation'
 import PropTypes from 'prop-types'
 
 const HORIZONTAL = 'horizontal'

--- a/react/modules/animation.js
+++ b/react/modules/animation.js
@@ -1,6 +1,4 @@
-// TODO: Move this to a separate npm package, along with Swipable
-
-import parseMeasure from './modules/parseMeasure'
+import parseMeasure from './parseMeasure'
 
 const animations = []
 

--- a/react/modules/getPointerPosition.tsx
+++ b/react/modules/getPointerPosition.tsx
@@ -1,0 +1,33 @@
+function isMouseEvent(event: TouchEvent | MouseEvent): event is MouseEvent {
+  return !!(event as MouseEvent).clientX
+}
+
+function isTouchEvent(event: TouchEvent | MouseEvent): event is TouchEvent {
+  const touches = (event as TouchEvent).touches
+  if (!touches) return false
+  return touches.length > 0
+}
+
+export default function getPointerPosition(event: TouchEvent | MouseEvent) {
+  if (isMouseEvent(event)) {
+    return {
+      x: event.clientX,
+      y: event.clientY,
+      source: 'mouse',
+      timeStamp: event.timeStamp,
+    }
+  }
+
+  if (!isTouchEvent(event)) {
+    return null
+  }
+
+  const touch = event.touches[0]
+
+  return {
+    x: touch.clientX,
+    y: touch.clientY,
+    source: 'touch',
+    timeStamp: event.timeStamp,
+  }
+}

--- a/react/modules/parseMeasure.tsx
+++ b/react/modules/parseMeasure.tsx
@@ -1,0 +1,23 @@
+type Measure = number | string
+
+type Value = number
+type Unit = string
+type IsUnitless = boolean
+
+type ParsedMeasure = [Value, Unit, IsUnitless]
+
+function parseMeasure(value: Measure): ParsedMeasure | null {
+  if (typeof value === 'number') {
+    return [value, 'px', true]
+  }
+  const matchResult = value.match(/([-\d]*)([^0-9\n]+)/)
+  if (!matchResult) {
+    return null
+  }
+  const parsedValue = matchResult[1]
+  const parsedUnit = matchResult[2]
+
+  return [parseInt(parsedValue), parsedUnit, false]
+}
+
+export default parseMeasure

--- a/react/modules/useLockScroll.tsx
+++ b/react/modules/useLockScroll.tsx
@@ -1,0 +1,94 @@
+import { useRef, useState, useEffect } from 'react'
+
+// https://stackoverflow.com/a/3464890/5313009
+const getScrollPosition = () => {
+  const documentElement =
+    window && window.document && window.document.documentElement
+  if (!documentElement) {
+    return 0
+  }
+  return (
+    (window.pageYOffset || documentElement.scrollTop) -
+    (documentElement.clientTop || 0)
+  )
+}
+
+const useLockScroll = () => {
+  const initialized = useRef(false)
+  const [isLocked, setLocked] = useState(false)
+  type ScrollPosition = number | null
+  const [lockedScrollPosition, setLockedScrollPosition] = useState<
+    ScrollPosition
+  >(null)
+
+  useEffect(() => {
+    if (!initialized.current && !isLocked) {
+      // Prevent this from running at first, if it's not locked.
+      // Important because this triggers re-layout, thus slowing
+      // down the rendering unnecessarily.
+      initialized.current = true
+      return
+    }
+    /** Locks scroll of the root HTML element if the
+     * drawer menu is open
+     */
+    const shouldLockScroll = isLocked
+
+    const documentElement =
+      window && window.document && window.document.documentElement
+
+    if (documentElement) {
+      const bodyBounds = document.body.getBoundingClientRect()
+
+      document.body.style.width = shouldLockScroll
+        ? `${bodyBounds.width}px`
+        : 'auto'
+
+      documentElement.style.overflow = shouldLockScroll ? 'hidden' : 'auto'
+
+      /** iOS doesn't lock the scroll of the body by just setting overflow to hidden.
+       * It requires setting the position of the HTML element to fixed, which also
+       * resets the scroll position.
+       * This code is intended to record the scroll position and set it as
+       * the element's position, and revert it once the menu is closed.
+       */
+      const scrollPosition =
+        lockedScrollPosition == null
+          ? getScrollPosition()
+          : lockedScrollPosition
+
+      if (lockedScrollPosition == null && shouldLockScroll) {
+        setLockedScrollPosition(scrollPosition)
+      }
+
+      if (lockedScrollPosition != null && !shouldLockScroll) {
+        window && window.scrollTo(0, scrollPosition)
+        setLockedScrollPosition(null)
+      }
+
+      documentElement.style.position = shouldLockScroll ? 'fixed' : 'static'
+
+      documentElement.style.top = shouldLockScroll
+        ? `-${scrollPosition}px`
+        : 'auto'
+
+      documentElement.style.bottom = shouldLockScroll ? '0' : 'auto'
+      documentElement.style.left = shouldLockScroll ? '0' : 'auto'
+    }
+
+    return () => {
+      documentElement.style.overflow = 'auto'
+      documentElement.style.position = 'static'
+
+      documentElement.style.top = 'auto'
+      documentElement.style.bottom = 'auto'
+      documentElement.style.left = 'auto'
+      document.body.style.width = 'auto'
+    }
+  }, [isLocked]) // eslint-disable-line react-hooks/exhaustive-deps
+  // ☝️ no need to trigger this on lockedScrollPosition changes
+
+  return setLocked
+}
+
+export default useLockScroll

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -2,10 +2,9 @@
   "compilerOptions": {
     "alwaysStrict": true,
     "esModuleInterop": true,
-    "allowJs": true,
     "jsx": "react",
     "lib": ["es2017", "dom", "es2018.promise"],
-    "module": "es6",
+    "module": "esnext",
     "moduleResolution": "node",
     "noImplicitAny": true,
     "noImplicitReturns": true,
@@ -19,7 +18,7 @@
     "strictPropertyInitialization": true,
     "target": "es2017",
     "typeRoots": ["node_modules/@types"],
-    "types": ["node", "jest", "graphql"]
+    "types": ["node", "jest"]
   },
   "exclude": ["node_modules"],
   "include": ["./typings/*.d.ts", "./**/*.tsx", "./**/*.ts"],


### PR DESCRIPTION
#### What is the purpose of this pull request?

Makes content render only after the drawer is open.
Also refactors Swipable, and keeps momentum on release.
Also fixes problem with SSR/CSR mismatch

https://drawer--storecomponents.myvtex.com/
Open the workspace on mobile mode, and click on both the minicart and the hamburger icon on the header to open the drawers.

Also fixes an "accordeon effect" that happens if the scrollbars are visible on the user's OS

Before:
![drawer-before-accordion](https://user-images.githubusercontent.com/5691711/71683011-16c7c780-2d70-11ea-9b24-ae3f6c465a3f.gif)
After:
![drawer-accordeon-after](https://user-images.githubusercontent.com/5691711/71683023-20512f80-2d70-11ea-800b-d99325297e28.gif)


<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
