### PR TITLE
Pass to lock the scroll in the body element instead of the html element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `useLockScroll` now blocks the scroll of the body element instead of the html.
 
 ## [0.6.0] - 2020-01-06
 ### Added

--- a/react/styles.css
+++ b/react/styles.css
@@ -1,0 +1,6 @@
+.hiddenBody {
+  overflow: hidden;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

As the title says

#### What problem is this solving?

The modal-layout needs to lock the scroll in its container (that usually is the `body`, but never the `html` tag), because of this when you have the drawer and the modal in the same page, the modal never locks the scroll because of the styles that the drawer is applying

#### How should this be manually tested?
[workspace](https://modallayout--storecomponents.myvtex.com/) open the modal and the drawer and check if both of them have block the scroll
![image](https://user-images.githubusercontent.com/8517023/72905056-ab3d9e00-3d0e-11ea-9982-725dd3ca0c99.png)


#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
