### PR TITLE
Use overflow hidden to lock page scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Lock page scroll with `overflow: hidden` instead of fixing its position.
 
 ## [0.10.0] - 2020-03-30
 ### Added

--- a/react/modules/useLockScroll.tsx
+++ b/react/modules/useLockScroll.tsx
@@ -1,103 +1,21 @@
 import { useRef, useState, useEffect } from 'react'
 
-import styles from '../styles.css'
-
-// https://stackoverflow.com/a/3464890/5313009
-const getScrollPosition = () => {
-  const documentElement = window?.document?.documentElement
-  if (!documentElement) {
-    return 0
-  }
-  return (
-    (window.pageYOffset || documentElement.scrollTop) -
-    (documentElement.clientTop || 0)
-  )
-}
-
-const propertiesNames = ['top', 'width'] as const
-
-interface PropertyStyle {
-  name: keyof CSSStyleDeclaration
-  value: string
-}
-
 const useLockScroll = () => {
-  const initialized = useRef(false)
-  const [isLocked, setLocked] = useState(false)
-  type ScrollPosition = number | null
-  const [lockedScrollPosition, setLockedScrollPosition] = useState<
-    ScrollPosition
-  >(null)
+  const [locked, setLocked] = useState(false)
+  const prevScroll = useRef('')
 
   useEffect(() => {
-    if (!initialized.current && !isLocked) {
-      // Prevent this from running at first, if it's not locked.
-      // Important because this triggers re-layout, thus slowing
-      // down the rendering unnecessarily.
-      initialized.current = true
-      return
+    if (locked) {
+      prevScroll.current = document.body.style.overflow
     }
-    /** Locks scroll of the root HTML element if the
-     * drawer menu is open
-     */
-    const shouldLockScroll = isLocked
-
-    if (window?.document) {
-      const bodyBounds = document.body.getBoundingClientRect()
-
-      /** iOS doesn't lock the scroll of the body by just setting overflow to hidden.
-       * It requires setting the position of the HTML element to fixed, which also
-       * resets the scroll position.
-       * This code is intended to record the scroll position and set it as
-       * the element's position, and revert it once the menu is closed.
-       */
-      const scrollPosition =
-        lockedScrollPosition == null
-          ? getScrollPosition()
-          : lockedScrollPosition
-
-      if (lockedScrollPosition == null && shouldLockScroll) {
-        setLockedScrollPosition(scrollPosition)
-      }
-
-      if (lockedScrollPosition != null && !shouldLockScroll) {
-        window?.scrollTo?.(0, scrollPosition)
-        setLockedScrollPosition(null)
-      }
-
-      const properties: PropertyStyle[] = [
-        {
-          name: 'top',
-          value: `-${scrollPosition}px`,
-        },
-        {
-          name: 'width',
-          value: `${bodyBounds.width}px`,
-        },
-      ]
-
-      if (shouldLockScroll) {
-        properties.forEach(prop => {
-          window.document.body.style[prop.name as any] = prop.value
-        })
-
-        window.document.body.classList.add(styles.hiddenBody)
-      } else {
-        properties.forEach(prop => {
-          window.document.body.style.removeProperty(prop.name as any)
-        })
-        window.document.body.classList.remove(styles.hiddenBody)
-      }
-    }
+    document.body.style.overflow = locked ? 'hidden' : prevScroll.current
 
     return () => {
-      propertiesNames.forEach(prop => {
-        window.document.body.style.removeProperty(prop)
-      })
-      window.document.body.classList.remove(styles.hiddenBody)
+      if (locked) {
+        document.body.style.overflow = prevScroll.current
+      }
     }
-  }, [isLocked]) // eslint-disable-line react-hooks/exhaustive-deps
-  // ☝️ no need to trigger this on lockedScrollPosition changes
+  }, [locked])
 
   return setLocked
 }

--- a/react/styles.css
+++ b/react/styles.css
@@ -1,6 +1,0 @@
-.hiddenBody {
-  overflow: hidden;
-  position: fixed;
-  bottom: 0;
-  left: 0;
-}


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR changes the mechanism of locking the page scroll. We were previously using a combination of `overflow:hidden` with `position: fixed` because of `iOS Safari < 12`. However, since `iOS 13` we are able to lock the scroll with a simple `overflow: hidden` added to the body. The previous solution caused sticky elements made with `vtex.sticky-layout` to disappear because it altered the scroll position of the whole page.

Related to: https://app.clubhouse.io/vtex/story/34649/header-disappears-when-use-drawer-in-desktop

#### How should this be manually tested?

1) Go to https://kiwi--storecomponents.myvtex.com/
2) Scroll a bit so the header gets fixed at the top
3) Open mini cart
4) Check the header is where it's supposed to be
5) Compare with http://storetheme.vtex.com/

You can test the same flow in an iOS device or in the iOS simulator.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12702016/78137968-8fd0cc80-73fc-11ea-9b22-f61f7590d02a.png)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
