### PR TITLE
Overflow y auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Scrollbar showing even when there's no overflow.
 
 ## [0.12.0] - 2020-04-28
 ### Added

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -193,10 +193,9 @@ function Drawer(props: Props) {
             }}
           >
             <div
-              className={handles.drawerContent}
+              className={`${handles.drawerContent} overflow-y-auto`}
               style={{
                 WebkitOverflowScrolling: 'touch',
-                overflowY: 'scroll',
               }}
             >
               {hasHeaderBlock ? (


### PR DESCRIPTION
#### What is the purpose of this pull request?

1. Change `overflow-y` from `scroll` to `auto`.
2. Use tachyon class instead of inline style.

#### What problem is this solving?

With `overflow-y` set to `scroll`, the scroll bar is always visible, even when there's no overflow.

Checkout cart in mobile:
![](https://user-images.githubusercontent.com/10400340/80545783-8b132000-898a-11ea-8d5b-f6fffa31be44.png)

#### How should this be manually tested?

Link this app or use this [Workspace](https://fixlayout--checkoutio.myvtex.com/).

#### Screenshots or example usage

Checkout cart in mobile after change:
![](https://user-images.githubusercontent.com/10400340/80545785-8d757a00-898a-11ea-8252-2ea13202d1fc.png)


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
