### PR TITLE
Fix exported TypeScript types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Exported TypeScript types.
 
 ## [0.13.0] - 2020-08-10
 ### Added

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -44,17 +44,17 @@ type Width = '100%' | 'auto'
 type BackdropMode = 'visible' | 'none'
 
 interface Props {
-  actionIconId: string
-  dismissIconId: string
-  position: Position
+  actionIconId?: string
+  dismissIconId?: string
+  position?: Position
   width?: Width
-  height: Height
+  height?: Height
   slideDirection?: SlideDirection
-  isFullWidth: boolean
+  isFullWidth?: boolean
   maxWidth?: number | string
   children: React.ReactNode
-  customIcon: React.ReactElement
-  header: React.ReactElement
+  customIcon?: React.ReactElement
+  header?: React.ReactElement
   backdropMode?: MaybeResponsiveValue<BackdropMode>
 }
 


### PR DESCRIPTION
#### What problem is this solving?

The exported TypeScript types were not taking into account the fact that the `Drawer` component can be used without any props being passed to it.

This is particularly relevant for Virtual Blocks.

#### How to test it?

Well, nothing should change visually, so this [Workspace](https://victormiranda--storecomponents.myvtex.com/) should look just fine.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/l0HlQ7LRalQqdWfao/giphy.gif)
