### PR TITLE
Add 'customPixelEventId' prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `customEventId` prop.
 
 ## [0.13.0] - 2020-08-10
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `customEventId` prop.
+- `customPixelEventId` prop.
 
 ## [0.13.0] - 2020-08-10
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -126,7 +126,7 @@ The `drawer` block accepts a few props that allow you to customize it.
 | `isFullWidth`        | `Boolean`                                                                  | Control whether or not the open Drawer should occupy the full available width.        | `false`        |
 | `slideDirection`     | `'horizontal'`&#124;`'vertical'`&#124;`'rightToLeft'`&#124;`'leftToRight'` | Controls the opening animation's direction.                                           | `'horizontal'` |
 | `backdropMode`       | `'default'`&#124;`'none'`                                                  | Controls if it should display the backdrop when the Drawer is open                    |
-| `customPixelEventId` | `string`                                                                   | Define the `id` of the event that will be listened to by the `drawer` to open itself. | `undefined`    |
+| `customPixelEventId` | `string`   | Store event ID responsible for triggering the `drawer` to automatically open itself on the interface. | `undefined`    |
 
 The `drawer-close-button` block accepts the following props to customize it:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -127,6 +127,7 @@ The `drawer` block accepts a few props that allow you to customize it.
 | `slideDirection`     | `'horizontal'`&#124;`'vertical'`&#124;`'rightToLeft'`&#124;`'leftToRight'` | Controls the opening animation's direction.                                           | `'horizontal'` |
 | `backdropMode`       | `'default'`&#124;`'none'`                                                  | Controls if it should display the backdrop when the Drawer is open                    |
 | `customPixelEventId` | `string`   | Store event ID responsible for triggering the `drawer` to automatically open itself on the interface. | `undefined`    |
+| `customPixelEventName` | `string`                                                                   | Store event name responsible for triggering the `drawer` to automatically open itself on the interface. Some examples are: `'addToCart'` and `'removeFromCart'` events. Notice that using this prop will make the drawer open in **every** event with the specified name if no `customPixelEventId` is specified. | `undefined`    |
 
 The `drawer-close-button` block accepts the following props to customize it:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -139,7 +139,7 @@ The `drawer-trigger` block accepts the following prop to customize it:
 
 | Prop name            | Type     | Description                                                           | Default value |
 | -------------------- | -------- | --------------------------------------------------------------------- | ------------- |
-| `customPixelEventId` | `string` | Define the `id` for the event that will be sent by the the trigger upon user click. | `undefined`   |
+| `customPixelEventId` | `string` | Defines the event ID to be sent whenever users interact with the Drawer component. | `undefined`   |
 
 ## Customization
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -118,40 +118,48 @@ const Menu = () => (
 
 ## Configuration
 
-The Drawer component accepts a few props that allow you to customize it.
+The `drawer` block accepts a few props that allow you to customize it.
 
-| Prop name        | Type                                                                       | Description                                                                    | Default value  |
-| ---------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | -------------- |
-| `maxWidth`       | `number` or `string`                                                       | Define the open Drawer's maximum width.                                        | `450`          |
-| `isFullWidth`    | `Boolean`                                                                  | Control whether or not the open Drawer should occupy the full available width. | `false`        |
-| `slideDirection` | `'horizontal'`&#124;`'vertical'`&#124;`'rightToLeft'`&#124;`'leftToRight'` | Controls the opening animation's direction.                                    | `'horizontal'` |
-| `backdropMode` | `'default'`&#124;`'none'` | Controls if it should display the backdrop when the Drawer is open |
+| Prop name            | Type                                                                       | Description                                                                           | Default value  |
+| -------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- | -------------- |
+| `maxWidth`           | `number` or `string`                                                       | Define the open Drawer's maximum width.                                               | `450`          |
+| `isFullWidth`        | `Boolean`                                                                  | Control whether or not the open Drawer should occupy the full available width.        | `false`        |
+| `slideDirection`     | `'horizontal'`&#124;`'vertical'`&#124;`'rightToLeft'`&#124;`'leftToRight'` | Controls the opening animation's direction.                                           | `'horizontal'` |
+| `backdropMode`       | `'default'`&#124;`'none'`                                                  | Controls if it should display the backdrop when the Drawer is open                    |
+| `customPixelEventId` | `string`                                                                   | Define the `id` of the event that will be listened to by the `drawer` to open itself. | `undefined`    |
 
-The `DrawerCloseButton` accepts the following props to customize it:
+The `drawer-close-button` block accepts the following props to customize it:
 
 | Prop name | Type                     | Description                                   | Default value |
 | --------- | ------------------------ | --------------------------------------------- | ------------- |
 | `size`    | `Number`                 | Define the size of the icon inside the button | `30`          |
 | `type`    | `'filled'`&#124;`'line'` | Define the type of the icon                   | `'line'`      |
 
+The `drawer-trigger` block accepts the following prop to customize it:
+
+| Prop name            | Type     | Description                                                           | Default value |
+| -------------------- | -------- | --------------------------------------------------------------------- | ------------- |
+| `customPixelEventId` | `string` | Define the `id` for the event that will be sent by the the trigger upon user click. | `undefined`   |
+
 ## Customization
 
 In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
 
-| CSS Handles          |
-| -------------------- |
-| `drawer`             |
-| `opened`             |
-| `overlay`            |
-| `overlay--visible`   |
-| `closed`             |
-| `moving`             |
-| `drawerContent`      |
-| `drawerHeader`       |
-| `openIconContainer`  |
-| `closeIconContainer` |
-| `closeIconButton`    |
-| `childrenContainer`  |
+| CSS Handles              |
+| ------------------------ |
+| `drawer`                 |
+| `opened`                 |
+| `overlay`                |
+| `overlay--visible`       |
+| `closed`                 |
+| `moving`                 |
+| `drawerContent`          |
+| `drawerHeader`           |
+| `drawerTriggerContainer` |
+| `openIconContainer`      |
+| `closeIconContainer`     |
+| `closeIconButton`        |
+| `childrenContainer`      |
 
 ## Contributors ✨
 

--- a/manifest.json
+++ b/manifest.json
@@ -13,11 +13,10 @@
   "dependencies": {
     "vtex.store-icons": "0.x",
     "vtex.css-handles": "0.x",
-    "vtex.responsive-values": "0.x"
+    "vtex.responsive-values": "0.x",
+    "vtex.pixel-manager": "1.x"
   },
   "mustUpdateAt": "2020-03-28",
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -10,6 +10,7 @@ import { IconMenu } from 'vtex.store-icons'
 import { useCssHandles } from 'vtex.css-handles'
 import { useChildBlock, ExtensionPoint } from 'vtex.render-runtime'
 import { usePixelEventCallback } from 'vtex.pixel-manager'
+import { PixelData } from 'vtex.pixel-manager/react/PixelContext'
 import {
   MaybeResponsiveValue,
   useResponsiveValue,
@@ -57,7 +58,8 @@ interface Props {
   customIcon: React.ReactElement
   header: React.ReactElement
   backdropMode?: MaybeResponsiveValue<BackdropMode>
-  customPixelEventId?: string
+  customPixelEventId: PixelData['id']
+  customPixelEventName: PixelData['event']
 }
 
 function menuReducer(state: MenuState, action: MenuAction) {
@@ -119,6 +121,7 @@ function Drawer(props: Partial<Props>) {
     slideDirection = 'horizontal',
     backdropMode: backdropModeProp = 'visible',
     customPixelEventId,
+    customPixelEventName,
   } = props
   const handles = useCssHandles(CSS_HANDLES)
   const backdropMode = useResponsiveValue(backdropModeProp)
@@ -128,7 +131,19 @@ function Drawer(props: Partial<Props>) {
   const { isOpen: isMenuOpen, hasBeenOpened: hasMenuBeenOpened } = menuState
   const [isMoving, setIsMoving] = useState(false)
 
-  usePixelEventCallback(customPixelEventId, openMenu)
+  // Always add the listener for 'openDrawer' events, since they're sent by
+  // the drawer-trigger block.
+  usePixelEventCallback({
+    eventId: customPixelEventId,
+    handler: openMenu,
+    eventName: 'openDrawer',
+  })
+
+  usePixelEventCallback({
+    eventId: customPixelEventId,
+    handler: openMenu,
+    eventName: customPixelEventName,
+  })
 
   const handleContainerClick: MouseEventHandler<HTMLElement> = event => {
     // target is the clicked element

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -57,7 +57,7 @@ interface Props {
   customIcon: React.ReactElement
   header: React.ReactElement
   backdropMode?: MaybeResponsiveValue<BackdropMode>
-  customEventId?: string
+  customPixelEventId?: string
 }
 
 function menuReducer(state: MenuState, action: MenuAction) {
@@ -118,7 +118,7 @@ function Drawer(props: Partial<Props>) {
     maxWidth = 450,
     slideDirection = 'horizontal',
     backdropMode: backdropModeProp = 'visible',
-    customEventId,
+    customPixelEventId,
   } = props
   const handles = useCssHandles(CSS_HANDLES)
   const backdropMode = useResponsiveValue(backdropModeProp)
@@ -128,7 +128,7 @@ function Drawer(props: Partial<Props>) {
   const { isOpen: isMenuOpen, hasBeenOpened: hasMenuBeenOpened } = menuState
   const [isMoving, setIsMoving] = useState(false)
 
-  usePixelEventCallback(customEventId, openMenu)
+  usePixelEventCallback(customPixelEventId, openMenu)
 
   const handleContainerClick: MouseEventHandler<HTMLElement> = event => {
     // target is the clicked element

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -9,6 +9,7 @@ import { defineMessages } from 'react-intl'
 import { IconMenu } from 'vtex.store-icons'
 import { useCssHandles } from 'vtex.css-handles'
 import { useChildBlock, ExtensionPoint } from 'vtex.render-runtime'
+import { useCustomEvents } from 'vtex.pixel-manager'
 import {
   MaybeResponsiveValue,
   useResponsiveValue,
@@ -56,6 +57,7 @@ interface Props {
   customIcon: React.ReactElement
   header: React.ReactElement
   backdropMode?: MaybeResponsiveValue<BackdropMode>
+  customEventId?: string
 }
 
 function menuReducer(state: MenuState, action: MenuAction) {
@@ -106,7 +108,7 @@ const CSS_HANDLES = [
   'closeIconContainer',
 ] as const
 
-function Drawer(props: Props) {
+function Drawer(props: Partial<Props>) {
   const {
     width,
     header,
@@ -116,6 +118,7 @@ function Drawer(props: Props) {
     maxWidth = 450,
     slideDirection = 'horizontal',
     backdropMode: backdropModeProp = 'visible',
+    customEventId,
   } = props
   const handles = useCssHandles(CSS_HANDLES)
   const backdropMode = useResponsiveValue(backdropModeProp)
@@ -124,6 +127,8 @@ function Drawer(props: Props) {
   const { state: menuState, openMenu, closeMenu } = useMenuState()
   const { isOpen: isMenuOpen, hasBeenOpened: hasMenuBeenOpened } = menuState
   const [isMoving, setIsMoving] = useState(false)
+
+  useCustomEvents(customEventId, openMenu)
 
   const handleContainerClick: MouseEventHandler<HTMLElement> = event => {
     // target is the clicked element

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -46,20 +46,20 @@ type Width = '100%' | 'auto'
 type BackdropMode = 'visible' | 'none'
 
 interface Props {
-  actionIconId: string
-  dismissIconId: string
+  actionIconId?: string
+  dismissIconId?: string
   position: Position
   width?: Width
-  height: Height
+  height?: Height
   slideDirection?: SlideDirection
-  isFullWidth: boolean
+  isFullWidth?: boolean
   maxWidth?: number | string
   children: React.ReactNode
-  customIcon: React.ReactElement
-  header: React.ReactElement
+  customIcon?: React.ReactElement
+  header?: React.ReactElement
   backdropMode?: MaybeResponsiveValue<BackdropMode>
-  customPixelEventId: PixelData['id']
-  customPixelEventName: PixelData['event']
+  customPixelEventId?: PixelData['id']
+  customPixelEventName?: PixelData['event']
 }
 
 function menuReducer(state: MenuState, action: MenuAction) {
@@ -110,7 +110,7 @@ const CSS_HANDLES = [
   'closeIconContainer',
 ] as const
 
-function Drawer(props: Partial<Props>) {
+function Drawer(props: Props) {
   const {
     width,
     header,

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -9,7 +9,7 @@ import { defineMessages } from 'react-intl'
 import { IconMenu } from 'vtex.store-icons'
 import { useCssHandles } from 'vtex.css-handles'
 import { useChildBlock, ExtensionPoint } from 'vtex.render-runtime'
-import { useCustomEvents } from 'vtex.pixel-manager'
+import { usePixelEventCallback } from 'vtex.pixel-manager'
 import {
   MaybeResponsiveValue,
   useResponsiveValue,
@@ -128,7 +128,7 @@ function Drawer(props: Partial<Props>) {
   const { isOpen: isMenuOpen, hasBeenOpened: hasMenuBeenOpened } = menuState
   const [isMoving, setIsMoving] = useState(false)
 
-  useCustomEvents(customEventId, openMenu)
+  usePixelEventCallback(customEventId, openMenu)
 
   const handleContainerClick: MouseEventHandler<HTMLElement> = event => {
     // target is the clicked element

--- a/react/DrawerTrigger.tsx
+++ b/react/DrawerTrigger.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react'
-import { usePixel } from 'vtex.pixel-manager/PixelContext'
+import { usePixel } from 'vtex.pixel-manager'
+import { PixelData } from 'vtex.pixel-manager/react/PixelContext'
 import { useCssHandles } from 'vtex.css-handles'
 
 interface Props {
@@ -17,7 +18,7 @@ const DrawerTrigger: FC<Props> = ({ children, customPixelEventId }) => {
       return
     }
 
-    const pixelEvent = {
+    const pixelEvent: PixelData = {
       id: customPixelEventId,
       event: 'openDrawer',
     }

--- a/react/DrawerTrigger.tsx
+++ b/react/DrawerTrigger.tsx
@@ -1,5 +1,41 @@
-import React, { Fragment, FC } from 'react'
+import React, { FC } from 'react'
+import { usePixel } from 'vtex.pixel-manager/PixelContext'
+import { useCssHandles } from 'vtex.css-handles'
 
-const DrawerTrigger: FC = ({ children }) => <Fragment>{children}</Fragment>
+interface Props {
+  customPixelEventId?: string
+}
+
+const CSS_HANDLES = ['drawerTriggerContainer'] as const
+
+const DrawerTrigger: FC<Props> = ({ children, customPixelEventId }) => {
+  const { push } = usePixel()
+  const handles = useCssHandles(CSS_HANDLES)
+
+  const handleInteraction = () => {
+    if (!customPixelEventId) {
+      return
+    }
+
+    const pixelEvent = {
+      id: customPixelEventId,
+      event: 'openDrawer',
+    }
+
+    push(pixelEvent)
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      className={handles.drawerTriggerContainer}
+      onClick={handleInteraction}
+      onKeyDown={handleInteraction}
+    >
+      {children}
+    </div>
+  )
+}
 
 export default DrawerTrigger

--- a/react/package.json
+++ b/react/package.json
@@ -16,7 +16,7 @@
     "@vtex/test-tools": "^3.0.0",
     "typescript": "3.8.3",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
-    "vtex.pixel-manager": "https://customevents--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.pixel-manager@1.2.0+build1599238552/public/@types/vtex.pixel-manager",
+    "vtex.pixel-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.3.0/public/@types/vtex.pixel-manager",
     "vtex.responsive-values": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.3.0/public/_types/react",
     "vtex.store-icons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.17.0/public/@types/vtex.store-icons"
   },

--- a/react/package.json
+++ b/react/package.json
@@ -15,8 +15,9 @@
     "@types/react-dom": "^16.8.4",
     "@vtex/test-tools": "^3.0.0",
     "typescript": "3.8.3",
-    "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.95.1/public/@types/vtex.render-runtime",
+    "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
+    "vtex.pixel-manager": "https://customevents--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.pixel-manager@1.2.0+build1599238552/public/@types/vtex.pixel-manager",
+    "vtex.responsive-values": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.3.0/public/_types/react",
     "vtex.store-icons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.17.0/public/@types/vtex.store-icons"
   },
   "version": "0.13.0"

--- a/react/typings/vtex.pixel-manager.d.ts
+++ b/react/typings/vtex.pixel-manager.d.ts
@@ -1,0 +1,1 @@
+declare module 'vtex.pixel-manager'

--- a/react/typings/vtex.pixel-manager.d.ts
+++ b/react/typings/vtex.pixel-manager.d.ts
@@ -1,2 +1,0 @@
-declare module 'vtex.pixel-manager'
-declare module 'vtex.pixel-manager/PixelContext'

--- a/react/typings/vtex.pixel-manager.d.ts
+++ b/react/typings/vtex.pixel-manager.d.ts
@@ -1,1 +1,2 @@
 declare module 'vtex.pixel-manager'
+declare module 'vtex.pixel-manager/PixelContext'

--- a/react/typings/vtex.render-runtime.d.ts
+++ b/react/typings/vtex.render-runtime.d.ts
@@ -1,7 +1,4 @@
-/* eslint-disable import/order */
-
-import 'vtex.render-runtime'
-
 declare module 'vtex.render-runtime' {
   export const useChildBlock: (opts: { id: string }) => {} | null
+  export const ExtensionPoint: any
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4805,13 +4805,17 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles":
-  version "0.4.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles#62ee61d1bb9efdc919e5cf4bb44fabcf9050d255"
+"vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles":
+  version "0.4.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles#8c45c6decf9acd2b944e07261686decff93d6422"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.95.1/public/@types/vtex.render-runtime":
-  version "8.95.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.95.1/public/@types/vtex.render-runtime#3aae291d0cd239d3059ea8ae8c3c2800ce36d22f"
+"vtex.pixel-manager@https://customevents--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.pixel-manager@1.2.0+build1599238552/public/@types/vtex.pixel-manager":
+  version "1.2.0"
+  resolved "https://customevents--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.pixel-manager@1.2.0+build1599238552/public/@types/vtex.pixel-manager#d7ceb1482b8a1f57d2998f5436f827eddadc41ec"
+
+"vtex.responsive-values@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.3.0/public/_types/react":
+  version "0.0.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.3.0/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
 "vtex.store-icons@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.17.0/public/@types/vtex.store-icons":
   version "0.17.0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4809,9 +4809,9 @@ verror@1.10.0:
   version "0.4.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles#8c45c6decf9acd2b944e07261686decff93d6422"
 
-"vtex.pixel-manager@https://customevents--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.pixel-manager@1.2.0+build1599238552/public/@types/vtex.pixel-manager":
-  version "1.2.0"
-  resolved "https://customevents--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.pixel-manager@1.2.0+build1599238552/public/@types/vtex.pixel-manager#d7ceb1482b8a1f57d2998f5436f827eddadc41ec"
+"vtex.pixel-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.3.0/public/@types/vtex.pixel-manager":
+  version "1.3.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.3.0/public/@types/vtex.pixel-manager#84e731e138aa3aaf98dd519e5cff929cdf3745d8"
 
 "vtex.responsive-values@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.3.0/public/_types/react":
   version "0.0.0"


### PR DESCRIPTION
#### What problem is this solving?

This enables users to make the `drawer` open due to an event with `eventId === customPixelEventId`.

By doing that, we can achieve behaviors such as opening the `minicart.v2` when a customer adds an item to the cart.

#### How to test it?

Go to [Workspace](https://customevents--storecomponents.myvtex.com/) and add an item to the cart. You should see the `minicart.v2` opening up. 

#### Screenshots or example usage:

![Aug-26-2020 13-36-52](https://user-images.githubusercontent.com/27777263/91331588-4e70fd00-e7a1-11ea-95d7-1d8ce026f87c.gif)

#### Related to / Depends on

Depends on https://github.com/vtex/pixel-manager/pull/29.

Also closes https://github.com/vtex-apps/store-discussion/issues/246.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/5VKbvrjxpVJCM/giphy.gif)
