### PR TITLE
fix: aria-hidden in swipable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- aria-hidden into `Swipable`
 
 ## [0.15.0] - 2020-12-04
 ### Added

--- a/react/Swipable.tsx
+++ b/react/Swipable.tsx
@@ -457,7 +457,7 @@ export default class Swipable extends React.Component<Props> {
   public render() {
     return (
       <div
-        aria-hidden
+        aria-hidden={this.props.enabled ? 'false' : 'true'}
         ref={this.dragContainer}
         style={{
           ...this.props.style,


### PR DESCRIPTION
#### What problem is this solving?

Aria Hidden into Swipable component always set as true, the client is asking for this to become false when the menu is opened 

#### How to test it?

[Workspace](https://iespinoza--motorolaus.myvtex.com/)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/13649073/110041392-c9a00680-7d22-11eb-8fef-b4daa69e65e8.png)


#### Related to / Depends on

Zendesk: #338771

#### How does this PR make you feel? [:link:](http://giphy.com/)

"Screen Reader"
![](https://media.giphy.com/media/l0HUbESbGqYn8kNlC/giphy.gif)
