### PR TITLE
Feature/editing close button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added 
+
+- Drawer Close Button text to change on site editor
+
 ## [0.16.0] - 2021-06-02
 ### Added
 - `renderingStrategy` prop to control when the drawer's children should be rendered

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,8 @@
     "vtex.store-icons": "0.x",
     "vtex.css-handles": "0.x",
     "vtex.responsive-values": "0.x",
-    "vtex.pixel-manager": "1.x"
+    "vtex.pixel-manager": "1.x",
+    "vtex.native-types": "0.x"
   },
   "mustUpdateAt": "2020-03-28",
   "registries": [

--- a/messages/context.json
+++ b/messages/context.json
@@ -1,3 +1,4 @@
 {
-  "admin/editor.drawer.title": "Drawer"
+  "admin/editor.drawer.title": "Drawer",
+  "admin/editor.drawer.drawer-close-button.title": "Drawer Close Button"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,3 +1,4 @@
 {
-  "admin/editor.drawer.title": "Drawer"
+  "admin/editor.drawer.title": "Drawer",
+  "admin/editor.drawer.drawer-close-button.title": "Drawer Close Button"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,3 +1,4 @@
 {
-  "admin/editor.drawer.title": "Drawer"
+  "admin/editor.drawer.title": "Drawer",
+  "admin/editor.drawer.drawer-close-button.title": "Drawer Botão Fechar"
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -13,6 +13,14 @@
     "composition": "children"
   },
   "drawer-close-button": {
-    "component": "DrawerCloseButton"
+    "component": "DrawerCloseButton",
+    "content": {
+      "properties": {
+        "text": {
+          "$ref": "app:vtex.native-types#/definitions/text",
+          "title": "admin/editor.drawer.drawer-close-button.title"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

Editing drawer close button text with site editor

#### How to test it?

Access workspace admin > site editor
And try to change the text on drawer close button (header mobile > menu > drawer baby > menu baby)

![image](https://user-images.githubusercontent.com/94458632/141995788-ef3d573a-f5df-4dbe-ae70-f0ec92245f9d.png)

[Workspace](https://rhb1296--rihappyio.myvtex.com/admin/cms/site-editor)

#### Screenshots or example usage:


![editing-drawer-close-button](https://user-images.githubusercontent.com/94458632/141996847-55aa3ded-2731-4ad5-89a6-5246e44704ff.gif)

#### Describe alternatives you've considered, if any.

N/A

#### Related to / Depends on

vtex.native-types

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/bbshzgyFQDqPHXBo4c/giphy.gif)
