### PR TITLE
Update/add function to close the menu with the enter key

### DIFF
--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -2,6 +2,7 @@ import React, {
   Suspense,
   useReducer,
   MouseEventHandler,
+  KeyboardEvent,
   useMemo,
   useState,
 } from 'react'
@@ -152,8 +153,13 @@ function Drawer(props: Props) {
     // target is the clicked element
     // currentTarget is the element which was attached the event (e.g. the container)
     const { target, currentTarget } = event
-
     if (isElementInsideLink(target as HTMLElement, currentTarget)) {
+      closeMenu()
+    }
+  }
+
+  const handleContainerEnter = (e: KeyboardEvent<HTMLElement>) => {
+    if(e.key === "Enter"){
       closeMenu()
     }
   }
@@ -241,6 +247,7 @@ function Drawer(props: Props) {
               <div
                 className={`${handles.childrenContainer} flex flex-grow-1`}
                 onClick={handleContainerClick}
+                onKeyUp = {handleContainerEnter}
               >
                 {shouldRenderChildren && children}
               </div>


### PR DESCRIPTION
#### What problem is this solving?

When the user searches the input for something and presses the enter key, the menu is not hidden, with this PR this error is already solved

<!--- What is the motivation and context for this change? -->

A client of my company noticed this "bug" and asked us to correct it

#### How to test it?

open the app and when looking for a product in a store you can give enter and it will close

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[feature653](https://feature653--yagmourio.myvtex.com/)

#### Screenshots or example usage:
[Loom](https://www.loom.com/share/b37ab69437ab43738e22efa110333b8a)

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

I can't find them

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
