### PR TITLE
Update Overlay.tsx

### DIFF
--- a/react/Overlay.tsx
+++ b/react/Overlay.tsx
@@ -23,7 +23,7 @@ const Overlay: RefForwardingComponent<HTMLDivElement, Props> = (
       style={{
         opacity: visible ? 0.5 : 0,
         pointerEvents: visible ? 'auto' : 'none',
-        transition: 'opacity 300ms',
+      
       }}
       className={`${applyModifiers(
         handles.overlay,


### PR DESCRIPTION
The transition of the overlay is resulting in opacity: 1 because of this Chrome Bug.  https://bugs.chromium.org/p/chromium/issues/detail?id=1330438&q=transition%20opacity&can=1

This issue is happening only in the newest Chrome version(Version 102.0.5005.61). At this moment, this is impacting all the stores, and Google is still trying to remediate this issue.

#### What problem is this solving?
When the minicart is opened, the overlay blocks the view of the rest of the page. 
<!--- What is the motivation and context for this change? -->
<img width="1434" alt="Screen Shot 2022-06-06 at 4 26 53 PM" src="https://user-images.githubusercontent.com/88678995/172243041-aa9a28b4-f586-4ee6-b5f1-1b3bb3e80d40.png">

#### How to test it?
Open minicar using Chrome Version 102.0.5005.61
<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://drawer--rjantsch.myvtex.com/)

#### Screenshots or example usage:
<img width="1437" alt="Screen Shot 2022-06-06 at 4 30 20 PM" src="https://user-images.githubusercontent.com/88678995/172243632-3070749d-775f-4271-b541-5ff1eed30a65.png">


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
