### PR TITLE
Added analytics event on drawer interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Added gtm event when a use clicks on drawer's icon, both for open and close interactions (vtex:drawerInteraction)
+### Added
+- gtm event when a user clicks on the drawer's icon for open and close interactions (vtex:drawerInteraction)
 ## [0.16.2] - 2022-06-13
 ### Fixed
 - Removed transition from in `"Overlay"`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+- Added gtm event when a use clicks on drawer's icon, both for open and close interactions (vtex:drawerInteraction)
 ## [0.16.2] - 2022-06-13
 ### Fixed
 - Removed transition from in `"Overlay"`.

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -83,7 +83,7 @@ function menuReducer(state: MenuState, action: MenuAction) {
 }
 
 const useMenuState = () => {
-  const {push}:any = usePixel()
+  const { push } = usePixel()
   const [state, dispatch] = useReducer(menuReducer, initialMenuState)
   const setLockScroll = useLockScroll()
 

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -96,7 +96,10 @@ const useMenuState = () => {
     setMenuOpen(true)
     push({ event: 'drawerInteraction', action: 'open' })
   }
-  const closeMenu = () => {setMenuOpen(false), push({event: 'drawerInteraction', action: "close"})}
+  const closeMenu = () => {
+    setMenuOpen(false)
+    push({ event: 'drawerInteraction', action: 'close' })
+  }
 
   return {
     state,

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -9,7 +9,7 @@ import { defineMessages } from 'react-intl'
 import { IconMenu } from 'vtex.store-icons'
 import { useCssHandles } from 'vtex.css-handles'
 import { useChildBlock, ExtensionPoint } from 'vtex.render-runtime'
-import { usePixelEventCallback } from 'vtex.pixel-manager'
+import { usePixelEventCallback, usePixel } from 'vtex.pixel-manager'
 import { PixelData } from 'vtex.pixel-manager/react/PixelContext'
 import {
   MaybeResponsiveValue,
@@ -83,6 +83,7 @@ function menuReducer(state: MenuState, action: MenuAction) {
 }
 
 const useMenuState = () => {
+  const {push}:any = usePixel()
   const [state, dispatch] = useReducer(menuReducer, initialMenuState)
   const setLockScroll = useLockScroll()
 
@@ -91,8 +92,8 @@ const useMenuState = () => {
     setLockScroll(value)
   }
 
-  const openMenu = () => setMenuOpen(true)
-  const closeMenu = () => setMenuOpen(false)
+  const openMenu = () => {setMenuOpen(true), push({event: 'drawerInteraction', action: "open"})}
+  const closeMenu = () => {setMenuOpen(false), push({event: 'drawerInteraction', action: "close"})}
 
   return {
     state,

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -92,7 +92,10 @@ const useMenuState = () => {
     setLockScroll(value)
   }
 
-  const openMenu = () => {setMenuOpen(true), push({event: 'drawerInteraction', action: "open"})}
+  const openMenu = () => {
+    setMenuOpen(true)
+    push({ event: 'drawerInteraction', action: 'open' })
+  }
   const closeMenu = () => {setMenuOpen(false), push({event: 'drawerInteraction', action: "close"})}
 
   return {


### PR DESCRIPTION
#### What problem is this solving?

By now, no analytics event is pushed when the user click on the open/close drawer icons in the header.

#### How to test it?

You can test here on mobile view: [Workspace](https://menupr--itwhirlpool.myvtex.com/)

#### Screenshots or example usage:

For testing you can reach the workspace link, go to mobile view and then press drawer icon:

![image](https://user-images.githubusercontent.com/81118704/182572744-9ed39a61-54be-4c0f-9ff4-159bbba36215.png)

Then if you look at the developer console and type **dataLayer** you can see that the event is correctly triggered:

![image](https://user-images.githubusercontent.com/81118704/182572896-31e0a346-31ab-4b2c-953c-ee2705d7dbf0.png)

You can also have a look at **enhancedEcommerceEvents.ts** file:

![image](https://user-images.githubusercontent.com/81118704/182573101-4d920337-64bf-4bd5-9b7c-b3308d933d08.png)


#### Describe alternatives you've considered, if any.

Obviously the event is fired both for **open** clicks and **close** ones and distinguished by the field ```action``` (```push({event: 'drawerInteraction', action: "open"})```) that can be **open** or **close**.

#### Related to / Depends on

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/UEggOy3De1CHeben5N/giphy.gif)
