### PR TITLE
Add onVisibilityChanged function as a property argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add onVisibilityChanged function as a property argument of the Drawer component
+
 ## [0.17.1] - 2024-02-28
 
 ## [0.17.0] - 2024-01-09

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -155,7 +155,7 @@ function Drawer(props: Props) {
     if (!!onVisibilityChanged) {
       onVisibilityChanged(isMenuOpen)
     }
-  }, [isMenuOpen])
+  }, [onVisibilityChanged, isMenuOpen])
 
   const handleContainerClick: MouseEventHandler<HTMLElement> = event => {
     // target is the clicked element

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -152,7 +152,7 @@ function Drawer(props: Props) {
   })
 
   useEffect(() => {
-    if (!!onVisibilityChanged) {
+    if (onVisibilityChanged !== undefined) {
       onVisibilityChanged(isMenuOpen)
     }
   }, [onVisibilityChanged, isMenuOpen])

--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -4,6 +4,7 @@ import React, {
   MouseEventHandler,
   useMemo,
   useState,
+  useEffect,
 } from 'react'
 import { defineMessages } from 'react-intl'
 import { IconMenu } from 'vtex.store-icons'
@@ -62,6 +63,7 @@ interface Props {
   renderingStrategy?: RenderingStrategy
   customPixelEventId?: PixelData['id']
   customPixelEventName?: PixelData['event']
+  onVisibilityChanged?: (visible: boolean) => void
 }
 
 function menuReducer(state: MenuState, action: MenuAction) {
@@ -125,6 +127,7 @@ function Drawer(props: Props) {
     renderingStrategy = 'lazy',
     customPixelEventId,
     customPixelEventName,
+    onVisibilityChanged,
   } = props
   const handles = useCssHandles(CSS_HANDLES)
   const backdropMode = useResponsiveValue(backdropModeProp)
@@ -147,6 +150,12 @@ function Drawer(props: Props) {
     handler: openMenu,
     eventName: customPixelEventName,
   })
+
+  useEffect(() => {
+    if (!!onVisibilityChanged) {
+      onVisibilityChanged(isMenuOpen)
+    }
+  }, [isMenuOpen])
 
   const handleContainerClick: MouseEventHandler<HTMLElement> = event => {
     // target is the clicked element


### PR DESCRIPTION
#### What problem is this solving?

There is no way to handle the Drawer open/close state in a parent component

#### How to test it?

Define onVisibilityChanged prop in a parent component:

![Снимок экрана 2024-08-02 в 14 37 16](https://github.com/user-attachments/assets/742febe9-ea4e-4926-83e4-2e8de31796ba)

This feature is used in the minicart linked app to handle closing of the Drawer:
https://devalex--dunnesstorespreprod.myvtex.com/

#### Related PR:

https://github.com/vtex-apps/minicart/pull/335
