### PR TITLE
feat: add zIndex property

### DIFF
--- a/react/Drawer.tsx
+++ b/react/Drawer.tsx
@@ -62,6 +62,7 @@ interface Props {
   renderingStrategy?: RenderingStrategy
   customPixelEventId?: PixelData['id']
   customPixelEventName?: PixelData['event']
+  zIndex?: number
 }
 
 function menuReducer(state: MenuState, action: MenuAction) {
@@ -125,6 +126,7 @@ function Drawer(props: Props) {
     renderingStrategy = 'lazy',
     customPixelEventId,
     customPixelEventName,
+    zIndex = 999,
   } = props
   const handles = useCssHandles(CSS_HANDLES)
   const backdropMode = useResponsiveValue(backdropModeProp)
@@ -194,7 +196,7 @@ function Drawer(props: Props) {
         )}
       </div>
       <Portal>
-        <Overlay visible={overlayVisible} onClick={closeMenu} />
+        <Overlay visible={overlayVisible} onClick={closeMenu} zIndex={zIndex} />
         <Suspense fallback={<React.Fragment />}>
           <Swipable
             {...{
@@ -216,6 +218,7 @@ function Drawer(props: Props) {
               maxWidth,
               minWidth: 280,
               pointerEvents: isMenuOpen ? 'auto' : 'none',
+              zIndex
             }}
           >
             <div

--- a/react/Overlay.tsx
+++ b/react/Overlay.tsx
@@ -4,12 +4,13 @@ import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 interface Props {
   visible: boolean
   onClick(event: React.MouseEvent | React.TouchEvent): void
+  zIndex?: number
 }
 
 const CSS_HANDLES = ['overlay'] as const
 
 const Overlay: RefForwardingComponent<HTMLDivElement, Props> = (
-  { visible, onClick }: Props,
+  { visible, onClick, zIndex = 999 }: Props,
   ref
 ) => {
   const handles = useCssHandles(CSS_HANDLES)
@@ -24,6 +25,7 @@ const Overlay: RefForwardingComponent<HTMLDivElement, Props> = (
         opacity: visible ? 0.5 : 0,
         pointerEvents: visible ? 'auto' : 'none',
         transition: 'opacity 300ms',
+        zIndex
       }}
       className={`${applyModifiers(
         handles.overlay,


### PR DESCRIPTION
#### What problem is this solving?

We have a situation where more than one Drawer needs to be opened and we need to be able to define which one is on top.

#### How to test it?
<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://dpfacets2--fulfillmentqa.myvtex.com/main-category-1)

#### Screenshots or example usage:

https://github.com/user-attachments/assets/42d352e3-75f8-4159-8ca8-ebc13325d569


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
